### PR TITLE
Fix borrower lookup for returning books

### DIFF
--- a/src/main/java/com/dushanz/bookmanager/service/BorrowRecordService.java
+++ b/src/main/java/com/dushanz/bookmanager/service/BorrowRecordService.java
@@ -96,7 +96,7 @@ public class BorrowRecordService {
 
         LOG.info("Book with id {} retrieved for return", bookId);
 
-        Borrower borrower = borrowerRepository.findById(borrowRecordDTO.getBookId())
+        Borrower borrower = borrowerRepository.findById(borrowRecordDTO.getBorrowerId())
                 .orElseThrow(() -> new ResourceNotFoundException("Borrower", "", ""));
 
         LOG.info("Borrower with id {} for return", borrower.getId());

--- a/src/test/java/com/dushanz/bookmanager/service/BorrowRecordServiceTest.java
+++ b/src/test/java/com/dushanz/bookmanager/service/BorrowRecordServiceTest.java
@@ -119,11 +119,11 @@ class BorrowRecordServiceTest {
     @Test
     void testReturnBook() {
         Integer bookId = 1;
-        Integer borrowerId = 1;
+        Integer borrowerId = 2;
 
         Book book = new Book();
         book.setId(bookId);
-        book.setIsBorrowed(Boolean.FALSE); // The book is currently borrowed
+        book.setIsBorrowed(Boolean.TRUE); // The book is currently borrowed
 
         Borrower borrower = new Borrower();
         borrower.setId(borrowerId);
@@ -139,11 +139,11 @@ class BorrowRecordServiceTest {
         when(borrowRecordRepository.save(any(BorrowRecord.class))).thenAnswer(i -> i.getArguments()[0]);
 
         BorrowRecordDTO dto = new BorrowRecordDTO();
-        dto.setBookId(1);
-        dto.setBorrowerId(1);
+        dto.setBookId(bookId);
+        dto.setBorrowerId(borrowerId);
         dto.setBorrowDate(DateUtils.formatLocalDateTime(LocalDateTime.now().minusWeeks(1)));
 
-        BorrowRecordDTO actualDto = service.returnBook(1, dto);
+        BorrowRecordDTO actualDto = service.returnBook(bookId, dto);
         assertEquals(bookId, actualDto.getBookId());
         assertEquals(borrowerId, actualDto.getBorrowerId());
         assertNotNull(actualDto.getReturnDate());


### PR DESCRIPTION
## Summary
- fix borrower retrieval by using borrowerId in returnBook
- add unit test covering returnBook with distinct book and borrower IDs

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c23ef6fc4832e800939fd93e52618