### PR TITLE
feat: hash user passwords

### DIFF
--- a/db-init/1_create_tables.sql
+++ b/db-init/1_create_tables.sql
@@ -62,9 +62,9 @@ ALTER TABLE borrow_record ADD INDEX idx_return_date (return_date);
 -- insert data
 -- USE library_db;
 
--- create default system user and role
+-- store encoded password instead of plaintext
 INSERT INTO users (username, password)
-VALUES ('user', '{noop}hgytbbAzk891');
+VALUES ('user', '$2b$10$XhaOwSpDz94qUc2zq5XJZuhroRpTyD5KEq.oFXWdRmoyvsJbBCM7y');
 
 -- get the id of the user just inserted
 SET @userId = (SELECT id FROM users WHERE username = 'user');

--- a/src/main/java/com/dushanz/bookmanager/security/SecurityConfiguration.java
+++ b/src/main/java/com/dushanz/bookmanager/security/SecurityConfiguration.java
@@ -5,12 +5,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -22,19 +26,22 @@ import org.springframework.stereotype.Service;
 public class SecurityConfiguration {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final UserDetailsService userDetailsService;
     @Value("${security.jwt.token.endpoint}")
     private String jwtTokenEndpoint;
     @Value("${security.logout.url}")
     private String logoutUrl;
 
     @Autowired
-    public SecurityConfiguration(JwtAuthenticationFilter authenticationFilter) {
+    public SecurityConfiguration(JwtAuthenticationFilter authenticationFilter, UserDetailsService userDetailsService) {
         this.jwtAuthenticationFilter = authenticationFilter;
+        this.userDetailsService = userDetailsService;
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, DaoAuthenticationProvider authProvider) throws Exception {
         http
+                .authenticationProvider(authProvider)
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(new AntPathRequestMatcher(jwtTokenEndpoint)).permitAll()
@@ -53,6 +60,19 @@ public class SecurityConfiguration {
                         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                 );
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
     }
 
 

--- a/src/main/java/com/dushanz/bookmanager/service/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/dushanz/bookmanager/service/security/UserDetailsServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -19,10 +20,12 @@ import java.util.Set;
 @Service
 public class UserDetailsServiceImpl implements UserDetailsService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Autowired
-    public UserDetailsServiceImpl(UserRepository userRepository) {
+    public UserDetailsServiceImpl(UserRepository userRepository, PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Override
@@ -32,6 +35,11 @@ public class UserDetailsServiceImpl implements UserDetailsService {
             throw new UsernameNotFoundException(username);
         }
         return new org.springframework.security.core.userdetails.User(user.getUsername(), user.getPassword(), convertRolesToAuthorities(user.getRoles()));
+    }
+
+    public User save(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        return userRepository.save(user);
     }
 
     private Collection<? extends GrantedAuthority> convertRolesToAuthorities(Set<String> roles) {


### PR DESCRIPTION
## Summary
- add BCrypt password encoding via DaoAuthenticationProvider
- encode user passwords on save
- store hashed password for default SQL user

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c50e4b2b4832e8b351ebcf9156990