### PR TITLE
fix: resolve bean dependency cycle in security config

### DIFF
--- a/src/main/java/com/dushanz/bookmanager/security/SecurityConfiguration.java
+++ b/src/main/java/com/dushanz/bookmanager/security/SecurityConfiguration.java
@@ -1,7 +1,6 @@
 package com.dushanz.bookmanager.security;
 
 import com.dushanz.bookmanager.security.filter.JwtAuthenticationFilter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
@@ -19,27 +18,20 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.stereotype.Service;
+import org.springframework.context.annotation.Configuration;
 
-@Service
+@Configuration
 @EnableWebSecurity
 public class SecurityConfiguration {
-
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final UserDetailsService userDetailsService;
     @Value("${security.jwt.token.endpoint}")
     private String jwtTokenEndpoint;
     @Value("${security.logout.url}")
     private String logoutUrl;
 
-    @Autowired
-    public SecurityConfiguration(JwtAuthenticationFilter authenticationFilter, UserDetailsService userDetailsService) {
-        this.jwtAuthenticationFilter = authenticationFilter;
-        this.userDetailsService = userDetailsService;
-    }
-
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, DaoAuthenticationProvider authProvider) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   JwtAuthenticationFilter jwtAuthenticationFilter,
+                                                   DaoAuthenticationProvider authProvider) throws Exception {
         http
                 .authenticationProvider(authProvider)
                 .csrf(AbstractHttpConfigurer::disable)
@@ -68,10 +60,11 @@ public class SecurityConfiguration {
     }
 
     @Bean
-    public DaoAuthenticationProvider authenticationProvider() {
+    public DaoAuthenticationProvider authenticationProvider(UserDetailsService userDetailsService,
+                                                            PasswordEncoder passwordEncoder) {
         DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
         authProvider.setUserDetailsService(userDetailsService);
-        authProvider.setPasswordEncoder(passwordEncoder());
+        authProvider.setPasswordEncoder(passwordEncoder);
         return authProvider;
     }
 


### PR DESCRIPTION
## Summary
- refactor security configuration to a pure configuration class
- inject dependencies through method parameters to avoid bean cycles

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c68035350832eb923330df9041deb